### PR TITLE
Added enough `muladd` methods to propagate `Zeros.Zero()`

### DIFF
--- a/src/Zeros.jl
+++ b/src/Zeros.jl
@@ -189,10 +189,11 @@ for op in [:fma :muladd]
     end
 end
 
-Base.muladd(::Zero,x::Complex,y::Number) = convert(promote_type(typeof(x),typeof(y)),y)
-Base.muladd(x::Complex,::Zero,y::Number) = convert(promote_type(typeof(x),typeof(y)),y)
-Base.muladd(x::Complex,::Zero,y::Complex) = convert(promote_type(typeof(x),typeof(y)),y)
-Base.muladd(x::Complex,::Zero,y::Real) = convert(promote_type(typeof(x),typeof(y)),y)
+Base.muladd(::Zero, x::Complex, y::Number) = convert(promote_type(typeof(x),typeof(y)),y)
+Base.muladd(::Zero, x::Complex, y::Union{Real, Complex}) = convert(promote_type(typeof(x),typeof(y)),y)
+Base.muladd(x::Complex, ::Zero, y::Number) = convert(promote_type(typeof(x),typeof(y)),y)
+Base.muladd(x::Complex, ::Zero, y::Complex) = convert(promote_type(typeof(x),typeof(y)),y)
+Base.muladd(x::Complex, ::Zero, y::Real) = convert(promote_type(typeof(x),typeof(y)),y)
 
 for op in (:mod, :rem), T in (:Real, :Rational)
   @eval Base.$op(::Zero, ::$T) = Zero()

--- a/src/Zeros.jl
+++ b/src/Zeros.jl
@@ -181,19 +181,18 @@ for op in [:fma :muladd]
     @eval Base.$op(::Zero, ::Zero, ::Zero) = Zero()
     @eval Base.$op(::Zero,::Number,::Zero) = Zero()
     @eval Base.$op(::Number,::Zero,::Zero) = Zero()
-    @eval Base.$op(x::Number, y::Number, ::Zero) = x*y
-    @eval Base.$op(::One, x::Number, y::Number) = x+y
-    @eval Base.$op(x::Number, ::One, y::Number) = x+y
-    for T in (Real, Complex) # Special definitions for Real and Complex to avoid method ambiguities.
-        @eval Base.$op(::Zero,::$T,::Zero) = Zero()
-        @eval Base.$op(::$T,::Zero,::Zero) = Zero()
-        for T2 in (Real, Complex)
-            @eval Base.$op(x::$T, y::$T2, ::Zero) = x*y
-            @eval Base.$op(::One, x::$T, y::$T2) = x+y
-            @eval Base.$op(x::$T, ::One, y::$T2) = x+y
+    for T in (Integer, Real, Complex) # Especial definitions for Real and Complex to avoid method ambiguities.
+        if !(op === :fma && T===Complex) #fma is not defined for complex numbers
+            @eval Base.$op(::Zero,::$T,::Zero) = Zero()
+            @eval Base.$op(::$T,::Zero,::Zero) = Zero()
         end
     end
 end
+
+Base.muladd(::Zero,x::Complex,y::Number) = convert(promote_type(typeof(x),typeof(y)),y)
+Base.muladd(x::Complex,::Zero,y::Number) = convert(promote_type(typeof(x),typeof(y)),y)
+Base.muladd(x::Complex,::Zero,y::Complex) = convert(promote_type(typeof(x),typeof(y)),y)
+Base.muladd(x::Complex,::Zero,y::Real) = convert(promote_type(typeof(x),typeof(y)),y)
 
 for op in (:mod, :rem), T in (:Real, :Rational)
   @eval Base.$op(::Zero, ::$T) = Zero()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -301,6 +301,12 @@ end
     @test muladd(1.0im,Z,3) === 3.0 + 0.0im
     @test fma(Z,Z,Z) === Z
     @test muladd(Z,Z,Z) === Z
+
+    @test invoke(muladd, Tuple{Zero,Number,Zero}, Z, 2.0, Z) === Z
+    @test invoke(muladd, Tuple{Number,Zero,Zero}, 2.0, Z, Z) === Z
+    @test invoke(muladd, Tuple{Zero,Complex,Number}, Z, 1.0im, 3) === 3.0 + 0.0im
+    @test invoke(muladd, Tuple{Complex,Zero,Number}, 1.0im, Z, 3) === 3.0 + 0.0im
+    @test invoke(muladd, Tuple{Complex,Zero,Complex}, 1.0im, Z, 3.0f0 + 0.0f0*im) === 3.0 + 0.0im
 end
 
 @testset "Complex" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,8 @@ using Test: @inferred
     for a in ambiguities
         println(a[1], "\n", a[2], "\n")
     end
-    @test length(ambiguities) <= 10
+    #@test length(ambiguities) <= 10
+    @test length(ambiguities) <= 1
 end
 
 const Z = Zero()
@@ -277,18 +278,30 @@ end
     @test I:3 === Base.OneTo(3)
 end
 
-# @testset "muladd" begin
-#     @test fma(Z,1,Z) === Z
-#     @test fma(Z,1.0,Z) === Z
-#     @test muladd(Z,1,Z) === Z
-#     @test muladd(Z,1.0,Z) === Z
-#     @test fma(Z,1,3) === 3
-#     @test fma(Z,1.0,3) === 3.0
-#     @test muladd(Z,1,3) === 3
-#     @test muladd(Z,1.0,3) === 3.0
-#     @test fma(Z,Z,Z) === Z
-#     @test muladd(Z,Z,Z) === Z
-# end
+@testset "muladd" begin
+    @test fma(Z,1,Z) === Z
+    @test fma(1,Z,Z) === Z
+    @test fma(Z,1.0,Z) === Z
+    @test fma(1.0,Z,Z) === Z
+    @test muladd(Z,1,Z) === Z
+    @test muladd(1,Z,Z) === Z
+    @test muladd(Z,1.0,Z) === Z
+    @test muladd(1.0,Z,Z) === Z
+    @test muladd(Z,im,Z) === Z
+    @test muladd(im,Z,Z) === Z
+    @test fma(Z,1,3) === 3
+    @test fma(1,Z,3) === 3
+    @test fma(Z,1.0,3) === 3.0
+    @test fma(1.0,Z,3) === 3.0
+    @test muladd(Z,1,3) === 3
+    @test muladd(1,Z,3) === 3
+    @test muladd(Z,1.0,3) === 3.0
+    @test muladd(1.0,Z,3) === 3.0
+    @test muladd(Z,1.0im,3) === 3.0 + 0.0im
+    @test muladd(1.0im,Z,3) === 3.0 + 0.0im
+    @test fma(Z,Z,Z) === Z
+    @test muladd(Z,Z,Z) === Z
+end
 
 @testset "Complex" begin
     @test Z*im === Z


### PR DESCRIPTION
Fixes #9

This PR adds enough `muladd` methods definition so that `muladd(::Zero,x::Number,::Zero)` always returns `Zeros.Zero()`.

I tried adding more simplifications, such as `muladd(x::Number,y::Number,::Zero) = x*y`, but they are probably unnecessary and that quickly led to a dozens of ambiguities rabbit hole...