### PR TITLE
Fix issue #11

### DIFF
--- a/src/Zeros.jl
+++ b/src/Zeros.jl
@@ -73,7 +73,7 @@ Base.inv(::One) = One()
 Base.inv(::Zero) = throw(DivideError())
 
 # Loop over rounding modes in order to make methods specific enough to avoid ambiguities.
-for R in (RoundingMode, RoundingMode{:Down}, RoundingMode{:Up}, Union{RoundingMode{:Nearest}, RoundingMode{:NearestTiesAway}, RoundingMode{:NearestTiesUp}})
+for R in (RoundingMode, RoundingMode{:Down}, RoundingMode{:Up}, RoundingMode{:FromZero}, Union{RoundingMode{:Nearest}, RoundingMode{:NearestTiesAway}, RoundingMode{:NearestTiesUp}})
     Base.div(x::Integer, ::One, ::R) = x
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -234,14 +234,39 @@ end
     @test Float64(Z) === 0.0
     @test Float64(I) === 1.0
 
-    @test Zero()^0 === true
-    @test Zero()^1 === false
+    t0(x) = x^0
+    tm0(x) = Base.literal_pow(^, x, Val(-0.0))
+    t1(x) = x^1
+    t2(x) = x^2
+    t_lit_throw(x) = x^-2
 
-    # Bypass litteral_pow
+    #test literal_pow
+    @test t0(Zero()) === I
+    @test tm0(Zero()) === I
+    @test t1(Zero()) === Z
+    @test t2(Zero()) === Z
+    @inferred t0(Zero())
+    @inferred tm0(Zero())
+    @inferred t1(Zero())
+    @inferred t2(Zero())
+
+    @test_throws DivideError t_lit_throw(Zero())
+
+    # Bypass literal_pow
     n0 = 0
     @test Zero()^n0 === true
     n1 = 1
     @test Zero()^n1 === false
+    n1f = 1.0
+    @test Zero()^n1f === false
+
+    @inferred Zero()^n1f
+
+    nm1 = -1
+    @test_throws DivideError Zero()^nm1
+
+    nm0 = -0.0
+    @test Zero()^nm0 === true
 
     @test hypot(-7, Z) === 7
     @test hypot(Z, -7) === 7


### PR DESCRIPTION
Avoid using `Base.to_power_type`. Fixes issue #11.

This fix also allows `Zero()^n` to return either `Zero` or `One` if the expression is lowered to `Base.literal_pow(^, Zero(), Val{n}()`, as opposed to returning a `Bool`.