### PR TITLE
Implement the `Random` API for `Zero`s and `One`s.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,14 @@ uuid = "bd1ec220-6eb4-527a-9b49-e79c3db6233b"
 authors = ["Per Rutquist <per.rutquist@gmail.com>"]
 version = "0.4.0"
 
+[weakdeps]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[extensions]
+ZerosRandomExt = "Random"
+
 [compat]
+Random = "1"
 julia = "1.0"
 
 [extras]

--- a/ext/ZerosRandomExt.jl
+++ b/ext/ZerosRandomExt.jl
@@ -1,0 +1,9 @@
+module ZerosRandomExt
+
+using Zeros
+
+import Random
+
+Random.rand(::Random.AbstractRNG, ::Random.SamplerType{T}) where T<:Zeros.StaticBool = T()
+
+end

--- a/src/Zeros.jl
+++ b/src/Zeros.jl
@@ -239,19 +239,26 @@ Base.Checked.checked_mul(x::StaticBool, y::StaticBool) = x*y
 Base.Checked.mul_with_overflow(x::StaticBool, y::StaticBool) = (x*y, false)
 Base.Checked.checked_add(x::StaticBool, y::StaticBool) = x+y
 
-if VERSION < v"1.2"
+@static if VERSION < v"1.2"
     # Disambiguation needed for older Julia versions
     Base.copysign(::Zero, x::Unsigned) = Zero()
     Base.flipsign(::Zero, x::Unsigned) = Zero()
 end
 
-if VERSION ≥ v"1.3"
+@static if VERSION ≥ v"1.3"
     # @eval, because this needs to parse in Julia 1.0, even though it will not run
     @eval begin
         export $(Symbol("𝟎")), $(Symbol("𝟏")) 
         const $(Symbol("𝟎")) = Zero()  # \bfzero <tab>
         const $(Symbol("𝟏")) = One()   # \bfone <tab>
     end
+end
+
+# From v1.9 on we define this method in the ZerosRandomExt extension, which is the proper
+# way of implementing functionallity into other modules without making it an explict dependency
+@static if VERSION < v"1.9"
+    import Random
+    Random.rand(::Random.AbstractRNG, ::Random.SamplerType{T}) where T<:StaticBool = T()
 end
 
 include("pirate.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -360,6 +360,14 @@ if VERSION ≥ v"1.2" # no test on 1.0 because of BenchmarkTools dependency
     end
 end
 
+@testset "Random" begin
+    @test rand(Zero) === Zero()
+    @test rand(One) === One()
+
+    @test rand(Zero,3) == zeros(Zero,3)
+    @test rand(One,3) == ones(One,3)
+end
+
 Zeros.@pirate Base
 
 @testset "piracy" begin


### PR DESCRIPTION
This PR makes `rand(Zero,...)` and `rand(One,...)` work.
Obviously, the result is not random at all; nevertheless, those are useful definitions for using `Zero`s and `One`s in generic code.
I'll be publishing a package of mine soon that actually relies on those definitions. Right now I'm defining those methods in my own package, but technically that is type piracy.

@perrutquist , I'll leave this PR open for a few days if you want to chime in before I merge it.
