### PR TITLE
Define constructors for `Union{StaticBool,<:Number}`.

### DIFF
--- a/src/Zeros.jl
+++ b/src/Zeros.jl
@@ -45,6 +45,14 @@ for T in (:Number, :Complex, :Rational, :BigFloat, :Zero, :One)
     @eval One(x::$T) = isone(x) ? One() : throw(InexactError(:One, One, x))
 end
 
+# Some useful definition for AbstractArray with Union eltype 
+Union{Zero, T}(x::Number) where {T<:Number} = T(x)::T
+Union{One, T}(x::Number) where {T<:Number} = T(x)::T
+Union{StaticBool, T}(x::Number) where {T<:Number} = T(x)::T
+Union{Zero, T}(x::Union{Zero, T}) where {T<:Number} = x
+Union{One, T}(x::Union{One, T}) where {T<:Number} = x
+Union{StaticBool, T}(x::Union{StaticBool, T}) where {T<:Number} = x
+
 Base.zero(::StaticBool) = Zero()
 Base.zero(::Type{<:StaticBool}) = Zero()
 Base.one(::StaticBool) = One()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,21 @@ const I = One()
     @test promote_type(Zero, Complex{Float64}) === Complex{Float64}
 end
 
+@testset "Union Types constructors" begin
+    @test Union{Zero,Float64}(1.0) === 1.0
+    @test Union{Zero,Float64}(Zero()) === Zero()
+    @test Union{Zero,Float64}(1) === 1.0
+
+    @test Union{One,Float64}(1.0) === 1.0
+    @test Union{One,Float64}(One()) === One()
+    @test Union{One,Float64}(1) === 1.0
+
+    @test Union{Zero,One,Float64}(1.0) === 1.0
+    @test Union{Zero,One,Float64}(Zero()) === Zero()
+    @test Union{Zero,One,Float64}(One()) === One()
+    @test Union{Zero,One,Float64}(1) === 1.0
+end
+
 @testset "Real" begin
     @test iszero(Z) === true
     @test isone(I) === true


### PR DESCRIPTION
These definitions are useful for arrays with `Union` eltype.
For example, the following code, without this PR, wouldn't work:

```
julia> using Zeros
Precompiling Zeros finished.
  1 dependency successfully precompiled in 1 seconds

julia> v = Vector{Union{Zero,Float64}}(undef,3)
3-element Vector{Union{Zero, Float64}}:
 𝟎
 𝟎
 𝟎

julia> v[1] = 1
1

julia> v
3-element Vector{Union{Zero, Float64}}:
 1.0
 𝟎
 𝟎
```

Before this PR:

```
julia> v = Vector{Union{Zero,Float64}}(undef,3)
3-element Vector{Union{Zero, Float64}}:
 𝟎
 𝟎
 𝟎

julia> v[1] = 1
ERROR: MethodError: no method matching Union{Zero, Float64}(::Int64)
The type `Union{Zero, Float64}` exists, but no method is defined for this combination of argument types when trying to construct it.

Closest candidates are:
  (::Type{T})(::T) where T<:Number
   @ Core boot.jl:965
  (::Type{T})(::AbstractChar) where T<:Union{AbstractChar, Number}
   @ Base char.jl:52
  (::Type{T})(::Complex) where T<:Real
   @ Base complex.jl:44
  ...

Stacktrace:
 [1] convert(::Type{Union{Zero, Float64}}, x::Int64)
   @ Base ./number.jl:7
 [2] setindex!(A::Vector{Union{Zero, Float64}}, x::Int64, i::Int64)
   @ Base ./array.jl:985
 [3] top-level scope
   @ REPL[4]:1
```