### PR TITLE
Add support for some operations between `StaticBool`s and `SIMD.Vec`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,20 +1,24 @@
 name = "Zeros"
 uuid = "bd1ec220-6eb4-527a-9b49-e79c3db6233b"
-authors = ["Per Rutquist <per.rutquist@gmail.com>"]
 version = "0.4.0"
+authors = ["Per Rutquist <per.rutquist@gmail.com>"]
 
 [weakdeps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 
 [extensions]
 ZerosRandomExt = "Random"
+ZerosSIMDExt = "SIMD"
 
 [compat]
 Random = "1"
+SIMD = "3"
 julia = "1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 
 [targets]
-test = ["Test"]
+test = ["Test", "SIMD"]

--- a/ext/ZerosSIMDExt.jl
+++ b/ext/ZerosSIMDExt.jl
@@ -1,0 +1,57 @@
+module ZerosSIMDExt
+
+using Zeros, SIMD
+using Zeros: StaticBool
+
+Base.:+(v::Vec, ::Zero) = v
+Base.:+(::Zero, v::Vec) = v
+
+Base.:+(v::Vec, ::One) = v + one(v)
+Base.:+(::One, v::Vec) = v + one(v)
+
+Base.:-(v::Vec, ::Zero) = v
+Base.:-(::Zero, v::Vec) = -v
+
+Base.:-(v::Vec, ::One) = v - one(v)
+Base.:-(::One, v::Vec) = one(v) - v
+
+Base.:*(v::Vec, ::One) = v
+Base.:*(::One, v::Vec) = v
+
+Base.:*(::Zero, ::Vec) = Zero()
+Base.:*(::Vec, ::Zero) = Zero()
+
+const BINARY_OPS = [
+    :(Base.div)
+    :(Base.rem)
+    :(Base.:^)
+    :(Base.:/)
+    :(Base.min)
+    :(Base.max)
+    :(Base.:(==))
+    :(Base.:!=)
+    :(Base.:>)
+    :(Base.:>=)
+    :(Base.:<)
+    :(Base.:<=)
+]
+
+for op in BINARY_OPS
+    @eval begin
+        $op(v::T, ::Zero) where {T <: Vec} = $op(v, zero(T))
+        $op(::Zero, v::T) where {T <: Vec} = $op(zero(T), v)
+        $op(v::T, ::One) where {T <: Vec} = $op(v, one(T))
+        $op(::One, v::T) where {T <: Vec} = $op(one(T), v)
+    end
+end
+
+for op in [:fma :muladd]
+    @eval Base.$op(a::Vec,b::StaticBool,c::StaticBool) = a * b + c
+    @eval Base.$op(a::StaticBool,b::Vec,c::StaticBool) = a * b + c
+    @eval Base.$op(a::StaticBool,b::StaticBool,c::Vec) = a * b + c
+    @eval Base.$op(a::Vec,b::Vec,c::StaticBool) = a * b + c
+    @eval Base.$op(a::Vec,b::StaticBool,c::Vec) = a * b + c
+    @eval Base.$op(a::StaticBool,b::Vec,c::Vec) = a * b + c
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Zeros
 using Test
 using Test: @inferred
+using SIMD
 
 @testset "ambiguities" begin
     ambiguities = detect_ambiguities(Base, Zeros)
@@ -381,6 +382,50 @@ end
 
     @test rand(Zero,3) == zeros(Zero,3)
     @test rand(One,3) == ones(One,3)
+end
+
+#Needs pacakge extensions support
+if VERSION >= v"1.9"
+
+    @testset "SIMD Extension" begin
+        let v = Vec(-2.0,2.0,0.01,0.5)
+
+            #We want to propagate Zero's
+            @test v*Zero() === Zero()
+            @test Zero()*v === Zero()
+            @test v*One() === v
+            @test One()*v === v
+
+            for op in (+,-,rem,^,/,min,max,==,!=,>,>=,<,<=)
+                @test op(v,Zero()) === op(v, zero(v))
+                @test op(Zero(),v) === op(zero(v), v)
+                @test op(v,One()) === op(v, one(v))
+                @test op(One(),v) === op(one(v), v)
+            end
+
+            for op in (fma, muladd)
+                #We want to propagate Zero's
+                @test op(Zero(), v, Zero()) === Zero()
+                @test op(v, Zero(), Zero()) === Zero()
+                for e1 in (v, Zero(), One())
+                    for e2 in (v, Zero(), One())
+                        for e3 in (v, Zero(), One())
+                            #test only if case has at least one of <:StaticBool and one of <:SIMD.Vec
+                            if !all(map(x->isa(x,Zeros.StaticBool), (e1,e2,e3))) && !all(map(x->isa(x,Vec), (e1,e2,e3)))
+                                @test op(e1,e2,e3) === (e1 * e2 + e3)
+                            end
+                        end
+                    end
+                end
+            end
+        end
+        let vi = Vec(-3,2,-1,4)
+            @test div(Zero(), vi) === div(zero(vi), vi)
+            @test div(One(), vi) === div(one(vi), vi)
+            @test div(vi, One()) === div(vi, one(vi))
+        end
+    end
+
 end
 
 Zeros.@pirate Base


### PR DESCRIPTION
… through a package extension.
`SIMD.Vec` is not defined as a `Number` subtype and the `SIMD.jl` module only defines operations between `Vec`s and some concrete numeric types from `Base`.

This PR defines some of the most common numeric operations so basic functions that operate on `Vec`s and `StaticBool`s work.