### PR TITLE
Avoid unecessary type promotion in `muladd` and `fma`.

### DIFF
--- a/src/Zeros.jl
+++ b/src/Zeros.jl
@@ -185,23 +185,45 @@ function Base.literal_pow(::typeof(Base.:^), ::Zero, ::Val{p}) where p
 end
 
 # Functions that perform a*b+c in one go
-for op in [:fma :muladd]
-    @eval Base.$op(::Zero, ::Zero, ::Zero) = Zero()
-    @eval Base.$op(::Zero,::Number,::Zero) = Zero()
-    @eval Base.$op(::Number,::Zero,::Zero) = Zero()
-    for T in (Integer, Real, Complex) # Especial definitions for Real and Complex to avoid method ambiguities.
-        if !(op === :fma && T===Complex) #fma is not defined for complex numbers
-            @eval Base.$op(::Zero,::$T,::Zero) = Zero()
-            @eval Base.$op(::$T,::Zero,::Zero) = Zero()
+Base.muladd(::Zero,::Number, z::Number) = z
+Base.muladd(::Number,::Zero, z::Number) = z
+Base.muladd(::Zero,::Zero, z::Number) = z
+Base.muladd(x::Number, y::Number, ::Zero) = x*y
+Base.muladd(::Number, ::Zero, ::Zero) = Zero()
+Base.muladd(::Zero, ::Number, ::Zero) = Zero()
+Base.muladd(::Zero, ::Zero, ::Zero) = Zero()
+for T in (Real, Complex)
+    @eval Base.muladd(::Zero,::$T, z::$T) = z
+    @eval Base.muladd(::$T,::Zero, z::$T) = z
+    @eval Base.muladd(::Zero,::Zero, z::$T) = z
+    @eval Base.muladd(x::$T, y::$T, ::Zero) = x*y
+    @eval Base.muladd(::$T, ::Zero, ::Zero) = Zero()
+    @eval Base.muladd(::Zero, ::$T, ::Zero) = Zero()
+    for T2 in (Real, Complex)
+        if (T2 !== T)
+            @eval Base.muladd(::Zero,::$T, z::$T2) = z
+            @eval Base.muladd(::Zero,::$T, z::$(Union{T2,T})) = z
+            @eval Base.muladd(::$T,::Zero, z::$T2) = z
+            @eval Base.muladd(x::$T, y::$T2, ::Zero) = x*y
         end
     end
 end
+Base.muladd(::Zero,::Zero, z::Union{Complex,Real}) = z
 
-Base.muladd(::Zero, x::Complex, y::Number) = convert(promote_type(typeof(x),typeof(y)),y)
-Base.muladd(::Zero, x::Complex, y::Union{Real, Complex}) = convert(promote_type(typeof(x),typeof(y)),y)
-Base.muladd(x::Complex, ::Zero, y::Number) = convert(promote_type(typeof(x),typeof(y)),y)
-Base.muladd(x::Complex, ::Zero, y::Complex) = convert(promote_type(typeof(x),typeof(y)),y)
-Base.muladd(x::Complex, ::Zero, y::Real) = convert(promote_type(typeof(x),typeof(y)),y)
+Base.fma(::Zero,::Real, z::Real) = z
+Base.fma(::Real,::Zero, z::Real) = z
+Base.fma(::Zero,::Zero, z::Real) = z
+Base.fma(x::Real, y::Real, ::Zero) = x*y
+Base.fma(::Real, ::Zero, ::Zero) = Zero()
+Base.fma(::Zero, ::Real, ::Zero) = Zero()
+Base.fma(::Zero, ::Zero, ::Zero) = Zero()
+
+Base.fma(::Zero,::Integer, z::Integer) = z
+Base.fma(::Integer,::Zero, z::Integer) = z
+Base.fma(::Zero,::Zero, z::Integer) = z
+Base.fma(x::Integer, y::Integer, ::Zero) = x*y
+Base.fma(::Integer, ::Zero, ::Zero) = Zero()
+Base.fma(::Zero, ::Integer, ::Zero) = Zero()
 
 for op in (:mod, :rem), T in (:Real, :Rational)
   @eval Base.$op(::Zero, ::$T) = Zero()

--- a/src/Zeros.jl
+++ b/src/Zeros.jl
@@ -209,6 +209,7 @@ for T in (Real, Complex)
     end
 end
 Base.muladd(::Zero,::Zero, z::Union{Complex,Real}) = z
+Base.muladd(::Zero,::Complex, z::Number) = z
 
 Base.fma(::Zero,::Real, z::Real) = z
 Base.fma(::Real,::Zero, z::Real) = z

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -354,6 +354,8 @@ end
 @testset "error handling" begin
     @test_throws InexactError Zero(1)
     @test_throws InexactError convert(Zero, 0.1)
+    @test_throws InexactError convert(Zero, One())
+    @test_throws InexactError convert(One, Zero())
     @test_throws DivideError 1.0/Z
     @test_throws DivideError (1.0+2.0im)/Z
     @test_throws DivideError Z/Z

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,8 +8,7 @@ using SIMD
     for a in ambiguities
         println(a[1], "\n", a[2], "\n")
     end
-    #@test length(ambiguities) <= 10
-    @test length(ambiguities) <= 1
+    @test length(ambiguities) == 0
 end
 
 const Z = Zero()
@@ -295,34 +294,32 @@ end
 end
 
 @testset "muladd" begin
-    @test fma(Z,1,Z) === Z
-    @test fma(1,Z,Z) === Z
-    @test fma(Z,1.0,Z) === Z
-    @test fma(1.0,Z,Z) === Z
-    @test muladd(Z,1,Z) === Z
-    @test muladd(1,Z,Z) === Z
-    @test muladd(Z,1.0,Z) === Z
-    @test muladd(1.0,Z,Z) === Z
-    @test muladd(Z,im,Z) === Z
-    @test muladd(im,Z,Z) === Z
-    @test fma(Z,1,3) === 3
-    @test fma(1,Z,3) === 3
-    @test fma(Z,1.0,3) === 3.0
-    @test fma(1.0,Z,3) === 3.0
-    @test muladd(Z,1,3) === 3
-    @test muladd(1,Z,3) === 3
-    @test muladd(Z,1.0,3) === 3.0
-    @test muladd(1.0,Z,3) === 3.0
-    @test muladd(Z,1.0im,3) === 3.0 + 0.0im
-    @test muladd(1.0im,Z,3) === 3.0 + 0.0im
-    @test fma(Z,Z,Z) === Z
-    @test muladd(Z,Z,Z) === Z
+    for a in (One(), Zero(), 2//1, 2, 2.0, 2.0 + 0.0im)
+        @test Base.invoke(muladd, Tuple{Number, Zero, Zero} , a, Zero(), Zero()) === Zero() 
+        @test Base.invoke(muladd, Tuple{Zero, Number, Zero}, Zero() , a, Zero()) === Zero() 
+        @test Base.invoke(muladd, Tuple{Zero, Zero, Number}, Zero(), Zero() , a) === a 
+        for b in (One(), Zero(), 3//1, 3, 3.0, 3.0 + 0.0im)
+            @test muladd(a, b, Zero()) === a*b
+            @test muladd(a, Zero(), b) === b
+            @test muladd(Zero(), a, b) === b
+            @test muladd(Zero(), Zero(), b) === b
+            @test Base.invoke(muladd, Tuple{Zero, Number, Number}, Zero() , a, b) === b 
+            @test Base.invoke(muladd, Tuple{Number, Zero, Number}, a, Zero() , b) === b 
+            @test Base.invoke(muladd, Tuple{Number, Number, Zero} , a, b, Zero()) === a*b 
+        end
+    end
+    @test Base.invoke(muladd, Tuple{Zero, Zero, Union{Real, Complex}}, Zero(), Zero() , 2.0+im) === 2.0+im 
+    @test Base.invoke(muladd, Tuple{Zero, Real, Union{Real, Complex}}, Zero(), 1.0 , 2.0+im) === 2.0+im 
 
-    @test invoke(muladd, Tuple{Zero,Number,Zero}, Z, 2.0, Z) === Z
-    @test invoke(muladd, Tuple{Number,Zero,Zero}, 2.0, Z, Z) === Z
-    @test invoke(muladd, Tuple{Zero,Complex,Number}, Z, 1.0im, 3) === 3.0 + 0.0im
-    @test invoke(muladd, Tuple{Complex,Zero,Number}, 1.0im, Z, 3) === 3.0 + 0.0im
-    @test invoke(muladd, Tuple{Complex,Zero,Complex}, 1.0im, Z, 3.0f0 + 0.0f0*im) === 3.0 + 0.0im
+    for a in (One(), Zero(), 2//1, 2, 2.0)
+        for b in (One(), Zero(), 3//1, 3, 3.0)
+            @test fma(a, b, Zero()) === a*b
+            @test fma(a, Zero(), b) === b
+            @test fma(Zero(), a, b) === b
+            @test fma(Zero(), Zero(), b) === b
+        end
+    end
+
 end
 
 @testset "Complex" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -297,6 +297,7 @@ end
     for a in (One(), Zero(), 2//1, 2, 2.0, 2.0 + 0.0im)
         @test Base.invoke(muladd, Tuple{Number, Zero, Zero} , a, Zero(), Zero()) === Zero() 
         @test Base.invoke(muladd, Tuple{Zero, Number, Zero}, Zero() , a, Zero()) === Zero() 
+        @test Base.invoke(muladd, Tuple{Zero, Complex, Number}, Zero(), 1.0 + 0.5im , a) === a 
         @test Base.invoke(muladd, Tuple{Zero, Zero, Number}, Zero(), Zero() , a) === a 
         for b in (One(), Zero(), 3//1, 3, 3.0, 3.0 + 0.0im)
             @test muladd(a, b, Zero()) === a*b


### PR DESCRIPTION
With this PR when using `muladd` and `fma` the result type will not be unnecessarily promoted anymore.
This allows `Zero`s and `One` to propagate further into function calls.

Before this PR:
```julia
julia> @code_typed muladd(Zero(), 2.0+im, One())
CodeInfo(
1 ─     return 1.0 + 0.0im
) => ComplexF64

julia> f(x) = muladd(Zero(), 2.0+im, x) - One()
f (generic function with 1 method)

julia> @code_typed f(One())
CodeInfo(
1 ─     return 0.0 + 0.0im
) => ComplexF64
```

After this PR:

```julia
julia> @code_typed muladd(Zero(), 2.0+im, One())
CodeInfo(
1 ─     return 𝟏
) => One

julia> f(x) = muladd(Zero(), 2.0+im, x) - One()
f (generic function with 1 method)

julia> @code_typed f(One())
CodeInfo(
1 ─     return 𝟎
) => Zero
```